### PR TITLE
feat: Add account_api_repository.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,3 +10,11 @@ module "alex_airbnb_repository" {
   repository_topics      = ["circleci", "terraform"]
   repository_has_issues  = true
 }
+
+module "account_api_repository" {
+  source                 = "./modules/alex_airbnb_repository"
+  repository_name        = "account_api"
+  repository_description = "Account API for the Account Bounded Context."
+  repository_topics      = ["circleci", "golang"]
+  repository_has_issues  = false
+}


### PR DESCRIPTION
Closes alex-airbnb/alex_airbnb#6

## Abstract

Add a new repository using the alex_airbnb_repository module called `account_api`.

## Checklist

- [ ] Updates documentation
- [ ] Updates environment variables
- [ ] Updates the CI/CD configuration
- [x] Updates the Infrastructure
- [ ] Updates depencies

## Additional Context

## Changes

- Add `account_api_repository`.